### PR TITLE
Use both android video services

### DIFF
--- a/src/commands/video.ts
+++ b/src/commands/video.ts
@@ -11,8 +11,8 @@ import {
   DeviceService,
   FfmpegService,
   XcodeVideoService,
-  AndroidVideoService,
-  AndroidVideoLegacyService,
+  AndroidVideoEmuService,
+  AndroidVideoShellService,
 } from '../services'
 import { deviceToFriendlyString } from '../helpers/device.helpers'
 import { waitForKeys } from '../helpers/keyboard'
@@ -34,7 +34,6 @@ export default class Video extends GithubIssueOnErrorCommand {
     ...commonFlags,
     gif: flags.boolean({ char: 'g', default: false }),
     hq: flags.boolean({ default: false }),
-    legacy: flags.boolean({ default: false }),
   }
 
   async run() {
@@ -49,16 +48,12 @@ export default class Video extends GithubIssueOnErrorCommand {
     let VideoKlass
 
     if (device.type === 'android') {
-      if (flags.legacy) {
-        this.log('Legacy Android flag detected.')
-        VideoKlass = AndroidVideoLegacyService
+      if (device.isEmulator) {
+        VideoKlass = AndroidVideoEmuService
       } else {
-        VideoKlass = AndroidVideoService
+        VideoKlass = AndroidVideoShellService
       }
     } else {
-      if (flags.legacy) {
-        this.log('Legacy flag is android only and has been ignored.')
-      }
       VideoKlass = XcodeVideoService
     }
 

--- a/src/services/android-video-emu.service.ts
+++ b/src/services/android-video-emu.service.ts
@@ -7,7 +7,7 @@ import { randomString } from '../helpers/random'
 import { Device } from './device.service'
 import { getFfmpegBin } from './ffmpeg.service'
 
-export default class AndroidVideo {
+export default class AndroidVideoEmu {
   fileName: string
 
   path: string
@@ -75,7 +75,7 @@ export default class AndroidVideo {
 
   private log(text: string) {
     if (this.verbose) {
-      console.log(`[android-video] ${text}`)
+      console.log(`[android-video-emu] ${text}`)
     }
   }
 }

--- a/src/services/android-video-shell.service.ts
+++ b/src/services/android-video-shell.service.ts
@@ -1,4 +1,4 @@
-import { isMac } from './../helpers/utils'
+import { isMac } from '../helpers/utils'
 import { spawn, ChildProcess, execSync } from 'child_process'
 import * as os from 'os'
 import * as fs from 'fs'
@@ -7,7 +7,7 @@ import { randomString } from '../helpers/random'
 import { Device } from './device.service'
 import { getFfmpegBin } from './ffmpeg.service'
 
-export default class AndroidVideo {
+export default class AndroidVideoShell {
   process: ChildProcess | null = null
 
   fileName: string
@@ -93,7 +93,7 @@ export default class AndroidVideo {
 
   private log(text: string) {
     if (this.verbose) {
-      console.log(`[android-video-legacy] ${text}`)
+      console.log(`[android-video-shell] ${text}`)
     }
   }
 }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,6 +1,6 @@
 export { default as AndroidScreenshotService } from './android-screenshot.service'
-export { default as AndroidVideoLegacyService } from './android-video-legacy.service'
-export { default as AndroidVideoService } from './android-video.service'
+export { default as AndroidVideoEmuService } from './android-video-emu.service'
+export { default as AndroidVideoShellService } from './android-video-shell.service'
 export { default as ConfigService } from './config.service'
 export { default as DeviceService } from './device.service'
 export { default as FfmpegService } from './ffmpeg.service'


### PR DESCRIPTION
Sadly AndroidVideoEmuService doesn't work on real devices, so this PR makes `tape video` use both the old one and the new one depending on the device type